### PR TITLE
Add Ubuntu Jammy (22.04)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python3.7 (3.7.12-1+jammy1) jammy; urgency=medium
+
+  * Build for jammy
+
+ -- Jason Perrin <jvperrin@yelp.com>  Thu, 20 Jan 2022 00:44:47 -0800
+
 python3.7 (3.7.12-1+focal2) focal; urgency=medium
 
   * Remove symbols and docs builds.
@@ -2289,7 +2295,7 @@ python2.5 (2.5.2-3) unstable; urgency=medium
     - Fix CVE-2008-1721, integer signedness error in the zlib extension module.
     - Fix urllib2 file descriptor happens byte-at-a-time, reverting
       a fix for excessively large memory allocations when calling .read()
-      on a socket object wrapped with makefile(). 
+      on a socket object wrapped with makefile().
   * Disable some regression tests on some architectures:
     - arm: test_compiler, test_ctypes.
     - armel: test_compiler.
@@ -2663,7 +2669,7 @@ python2.4 (2.4.3-4) unstable; urgency=low
   * Fix typo in pdb(1). Closes: #365772.
   * New autoconf likes the mandir in /usr/share instead of /usr; work
     with both locations. Closes: #367618.
-	
+
  -- Matthias Klose <doko@debian.org>  Wed,  7 Jun 2006 21:37:20 +0200
 
 python2.4 (2.4.3-3) unstable; urgency=low
@@ -2833,7 +2839,7 @@ python2.4 (2.4.1-2) unstable; urgency=low
 python2.4 (2.4.1-1ubuntu2) breezy; urgency=low
 
   * Add the debug symbols for the python2.4, python2.4-minimal, python2.4-gdbm
-    and python2.4-tk packages to the python2.4-dbg package. Ubuntu 10261, 
+    and python2.4-tk packages to the python2.4-dbg package. Ubuntu 10261,
   * Add gdbinit example to doc directory.
   * For os.utime, use utimes(2), correctly working with glibc-2.3.5.
     Ubuntu 10294.
@@ -2906,7 +2912,7 @@ python2.4 (2.4dfsg-1ubuntu4) hoary; urgency=medium
     - Don't map 'utf8', 'utf-8' to 'utf', which is not a known encoding
       for glibc.
   * os.py: Avoid using items() in environ.update(). Fixes #1124513.
-  * Python/pythonrun.c: 
+  * Python/pythonrun.c:
   * Build depend on locales, generate the locales needed for the
     testsuite.
   * Add build dependency on libbluetooth1-dev, adding some bluetooth
@@ -2989,8 +2995,8 @@ python2.4 (2.4-6) unstable; urgency=low
 
 python2.4 (2.4-5) unstable; urgency=high
 
-  * Fix a flaw in SimpleXMLRPCServerthat can affect any XML-RPC servers.  
-    This affects any programs have been written that allow remote 
+  * Fix a flaw in SimpleXMLRPCServerthat can affect any XML-RPC servers.
+    This affects any programs have been written that allow remote
     untrusted users to do unrestricted traversal and can allow them to
     access or change function internals using the im_* and func_* attributes.
     References: CAN-2005-0089.
@@ -3240,7 +3246,7 @@ python2.3 (2.3.3-6) unstable; urgency=low
   * Don't build python-elisp from the python2.3 source anymore,
     get it from python-mode.sf.net as a separate source package.
   * python2.3-dev suggests libc-dev (closes: #231091).
-  * get LDSHARED and CCSHARED (like, CC, CXX, CPP, CFLAGS) from 
+  * get LDSHARED and CCSHARED (like, CC, CXX, CPP, CFLAGS) from
     the environment
   * Set CXX in installed config/Makefile (closes: #230273).
 

--- a/debian/patches/newer-libmpdec.patch
+++ b/debian/patches/newer-libmpdec.patch
@@ -1,0 +1,49 @@
+Index: python3.7/Modules/_decimal/_decimal.c
+===================================================================
+--- python3.7.orig/Modules/_decimal/_decimal.c
++++ python3.7/Modules/_decimal/_decimal.c
+@@ -58,6 +58,13 @@
+ 
+ #define BOUNDS_CHECK(x, MIN, MAX) x = (x < MIN || MAX < x) ? MAX : x
+ 
++#ifndef UNUSED
++#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
++  #define UNUSED __attribute__((unused))
++#else
++  #define UNUSED
++#endif
++#endif
+ 
+ /* _Py_DEC_MINALLOC >= MPD_MINALLOC */
+ #define _Py_DEC_MINALLOC 4
+@@ -3277,7 +3284,7 @@ dec_format(PyObject *dec, PyObject *args
+     }
+     else {
+         size_t n = strlen(spec.dot);
+-        if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
++        if (n > 1 || (n == 1 && !isascii((unsigned char)spec.dot[0]))) {
+             /* fix locale dependent non-ascii characters */
+             dot = dotsep_as_utf8(spec.dot);
+             if (dot == NULL) {
+@@ -3286,7 +3293,7 @@ dec_format(PyObject *dec, PyObject *args
+             spec.dot = PyBytes_AS_STRING(dot);
+         }
+         n = strlen(spec.sep);
+-        if (n > 1 || (n == 1 && !isascii((uchar)spec.sep[0]))) {
++        if (n > 1 || (n == 1 && !isascii((unsigned char)spec.sep[0]))) {
+             /* fix locale dependent non-ascii characters */
+             sep = dotsep_as_utf8(spec.sep);
+             if (sep == NULL) {
+Index: python3.7/setup.py
+===================================================================
+--- python3.7.orig/setup.py
++++ python3.7/setup.py
+@@ -2051,7 +2051,7 @@ class PyBuildExt(build_ext):
+         undef_macros = []
+         if '--with-system-libmpdec' in sysconfig.get_config_var("CONFIG_ARGS"):
+             include_dirs = []
+-            libraries = [':libmpdec.so.2']
++            libraries = [':libmpdec.so.3']
+             sources = ['_decimal/_decimal.c']
+             depends = ['_decimal/docstrings.h']
+         else:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,3 +27,4 @@ reproducible-buildinfo.diff
 pydoc-use-pager.diff
 temporary-changes.diff
 0036-Disable-broken-dbm.ndbm-tests.patch
+newer-libmpdec.patch


### PR DESCRIPTION
First off, I don't actually want to merge this to the focal branch, it should be a separate `ubuntu/jammy` branch but that's not an option via a PR it seems. I've just made this as a draft for now due to that, but it depends on https://github.com/deadsnakes/runbooks/pull/12 to function.

The main interesting thing here was a couple patches I had to add for libmpdec:

- Backport the backport from https://github.com/python/cpython/commit/16eea45fbd3b7c3d1b222b7eb7a5d7ee427f70bd even further (from 3.8 back to 3.7)
- Take part of the patch from https://cgit.freebsd.org/ports/commit/?id=9738c1c2eadc9a8bd599397bcfbf84c37844a554 to use `unsigned char` instead of `uchar` and specify the correct library version

Otherwise this build went quite smoothly and `../runbooks/build` and `../runbooks/quick-test --distrib-codename jammy` both worked fine.